### PR TITLE
CEC Input command action now works independently of zone

### DIFF
--- a/custom_components/orei_hdmi_matrix/const.py
+++ b/custom_components/orei_hdmi_matrix/const.py
@@ -54,6 +54,8 @@ ATTR_HDCP: Final = "hdcp"
 
 ATTR_INPUT_EDID: Final = "input_edid"
 
+ATTR_INPUT_NUM: Final = "input_num"
+
 ATTR_INPUT_ACTIVE: Final = "input_active"
 
 ATTR_CEC_CMD: Final = "cec_cmd"

--- a/custom_components/orei_hdmi_matrix/media_player.py
+++ b/custom_components/orei_hdmi_matrix/media_player.py
@@ -35,6 +35,7 @@ from .const import (
     ATTR_HDCP,
     ATTR_INPUT_ACTIVE,
     ATTR_INPUT_EDID,
+    ATTR_INPUT_NUM,
     ATTR_SCALER_MODE,
     ATTR_SOURCE,
     ATTR_STREAM,
@@ -127,7 +128,7 @@ SERVICE_OUTPUT_CEC_SCHEMA = vol.Schema(
 
 SERVICE_INPUT_CEC_SCHEMA = vol.Schema(
     {
-        vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+        vol.Required(ATTR_INPUT_NUM): vol.All(vol.Coerce(int), vol.In(range(1, 9))),
         vol.Required(ATTR_CEC_CMD): cv.enum(InputCECCommands),
     }
 )
@@ -290,21 +291,9 @@ def setup_platform(
 
     def input_cec_command_service_handle(service):
         """Handler for sending input CEC command."""
-        entity_ids = service.data.get(ATTR_ENTITY_ID)
+        input_id = service.data.get(ATTR_INPUT_NUM) - 1
         cmd = service.data.get(ATTR_CEC_CMD)
-
-        if entity_ids:
-            devices = [
-                device
-                for device in hass.data[DATA_HDMIMATRIX].values()
-                if device.entity_id in entity_ids
-            ]
-        else:
-            devices = hass.data[DATA_HDMIMATRIX].values()
-
-        for device in devices:
-            if service.service == SERVICE_INPUT_CEC:
-                device.input_cec_command(cmd)
+        matrix_api.input_cec_command(host, input_id, cmd)
 
     hass.services.register(
         DOMAIN,
@@ -514,10 +503,3 @@ class HDMIMatrixZone(MediaPlayerEntity):
             f"Sending output id {self._name}={self._zone_id} CEC command: {cmd.name}={cmd.value}"
         )
         matrix_api.output_cec_command(self._host, (self._zone_id - 1), cmd)
-
-    def input_cec_command(self, cmd: InputCECCommands):
-        """Send input CEC command."""
-        _LOGGER.info(
-            f"Sending input id {self._source_names[self._source_id - 1]}={self._source_id} CEC command: {cmd.name}={cmd.value}"
-        )
-        matrix_api.input_cec_command(self._host, (self._source_id - 1), cmd)


### PR DESCRIPTION
The `media_player.hdmi_matrix_input_cec` service call now requires `input_num` data instead of `entity_id`.

This makes it possible to send input CEC commands without having to know which output (zone) the input is connected to.

example action:

```yaml
action: media_player.hdmi_matrix_input_cec
data:
  input_num: 1
  cec_cmd: POWER_OFF
```